### PR TITLE
net: openthread: Added config options for NCP vendor hooks.

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -286,6 +286,12 @@ config OPENTHREAD_NCP_SPINEL_ON_UART_ACM
 	help
 	  Is the SPINEL device a USB-CDC-ACM device
 
+config OPENTHREAD_NCP_VENDOR_HOOK_SOURCE
+	string "Path to NCP vendor hook source file"
+	depends on OPENTHREAD_NCP
+	help
+	  Provides path to compile ncp vendor hook file inside NCP component
+
 config OPENTHREAD_UDP_FORWARD
 	bool "UDP forward support"
 	help


### PR DESCRIPTION
New config options that can be used to set vendor hooks for NCP component.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>