### PR TITLE
net: openthread: Added config options for EUI64 and OUI.

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -42,4 +42,18 @@ config IEEE802154_NRF5_EXT_IRQ_MGMT
 	  the system. One example of external radio IRQ provider could be
 	  a radio arbiter used in dynamic multiprotocol applications.
 
+config IEEE802154_NRF5_VENDOR_OUI
+	int "Vendor Organizationally Unique Identifier"
+	default 16043574
+	help
+	  Custom vendor OUI for OpenThread,
+	  which makes 24 oldest bits of MAC address
+
+config IEEE802154_NRF5_EUI64_CUSTOM_SOURCE
+	bool "Custom EUI64 source support"
+	help
+	  Enable providing EUI64 address
+	  by custom, user implemented
+	  nrf5_get_eui64() method
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -60,10 +60,26 @@ static struct nrf5_802154_data nrf5_data;
 #define NRF5_802154_CFG(dev) \
 	((const struct nrf5_802154_config * const)(dev)->config_info)
 
+#if !CONFIG_IEEE802154_NRF5_EUI64_CUSTOM_SOURCE
 static void nrf5_get_eui64(uint8_t *mac)
 {
-	memcpy(mac, (const uint32_t *)&NRF_FICR->DEVICEID, 8);
+	uint64_t factoryAddress;
+	uint32_t index = 0;
+
+	/* Set the MAC Address Block Larger (MA-L) formerly called OUI. */
+	mac[index++] = (CONFIG_IEEE802154_NRF5_VENDOR_OUI >> 16) & 0xff;
+	mac[index++] = (CONFIG_IEEE802154_NRF5_VENDOR_OUI >> 8) & 0xff;
+	mac[index++] = CONFIG_IEEE802154_NRF5_VENDOR_OUI & 0xff;
+
+	/* Use device identifier assigned during the production. */
+	factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
+	factoryAddress |= NRF_FICR->DEVICEID[1];
+	memcpy(mac + index, &factoryAddress, sizeof(factoryAddress) - index);
 }
+#else
+/* User defined implementation of method */
+extern void nrf5_get_eui64(uint8_t *mac);
+#endif
 
 static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 {


### PR DESCRIPTION
Support for EUI64 address source customization and defining
vendor specific OUI (Organizationally Unique Identifier) was added.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>