### PR TITLE
net: openthread: radio: Removed retranssmisions from radio caps.

### DIFF
--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -611,8 +611,7 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 	}
 
 	if (radio_caps & IEEE802154_HW_CSMA) {
-		caps |= OT_RADIO_CAPS_CSMA_BACKOFF |
-			OT_RADIO_CAPS_TRANSMIT_RETRIES;
+		caps |= OT_RADIO_CAPS_CSMA_BACKOFF;
 	}
 
 	if (radio_caps & IEEE802154_HW_TX_RX_ACK) {


### PR DESCRIPTION
Zephyr platform does not support MAC retransmissions on its own,
so OT_RADIO_CAPS_TRANSMIT_RETRIES capability was removed.
It should not be enabled basing on IEEE802154_HW_CSMA support,
as these are quite seperate features. Current implementation
assumes that platform performs retransmissions on its own,
what is not provided and leads to lack of MAC retransmissions.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>