### PR TITLE
[include/posix] Fix incorrect casting of timeval on zsock_timeval.

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -16,14 +16,24 @@
 
 #include <zephyr/types.h>
 
+#ifdef CONFIG_POSIX_API
+#include <sys/_timeval.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct zsock_timeval {
+#ifdef CONFIG_POSIX_API
+	/* Rely on the standard libc types */
+	time_t tv_sec;
+	suseconds_t tv_usec;
+#else
 	/* Using longs, as many (?) implementations seem to use it. */
 	long tv_sec;
 	long tv_usec;
+#endif
 };
 
 typedef struct zsock_fd_set {


### PR DESCRIPTION
Current implementation of select() method wrongly assumes that
timeval type can be directly casted into zsock_timeval, while it's
true only when using CONFIG_NET_SOCKETS_POSIX_NAMES. In other case
i.e. using CONFIG_POSIX_API, timeval is provided by standard lib
and mentioned two structure types have fields of different size,
what leads to assigning them incorrect values.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>